### PR TITLE
make the cnn_tain.m be compatible with windows

### DIFF
--- a/examples/cnn_train.m
+++ b/examples/cnn_train.m
@@ -89,6 +89,7 @@ for epoch=1:opts.numEpochs
   modelPath = fullfile(opts.expDir, 'net-epoch-%d.mat') ;
   modelFigPath = fullfile(opts.expDir, 'net-train.pdf') ;
   if opts.continue
+    modelPath(strfind(modelPath,'\')) = '/';
     if exist(sprintf(modelPath, epoch),'file'), continue ; end
     if epoch > 1
       fprintf('resuming by loading epoch %d\n', epoch-1) ;


### PR DESCRIPTION
Add one sentence to make the file  "cnn_tain.m"  be compatible with windows。
If there is no "modelPath(strfind(modelPath,'\')) = '/';", matlab will say a error about '\c' .
