### PR TITLE
Fixed compilation in GPU-less mode.

### DIFF
--- a/matlab/src/vl_nnconv.cu
+++ b/matlab/src/vl_nnconv.cu
@@ -389,6 +389,8 @@ void mexFunction(int nout, mxArray *out[],
   bool tempIsValid = true;
 #else
   bool const gpuMode = false ;
+  bool const allOnesIsValid = true;
+  bool const tempIsValid = true;
 #endif
   bool backMode = false ;
   bool hasFilters = false ;


### PR DESCRIPTION
Compilation in GPU-less mode is broken because of d39e0d24992a50ed1f7bdf190a8bcc2106887dce:
```
>> vl_compilenn
...
Error using mex
In file included from /Users/mfigurnov/Documents/matconvnet-github/matlab/src/vl_nnconv.cpp:5:
/Users/mfigurnov/Documents/matconvnet-github/matlab/src/vl_nnconv.cu:689:10: error: use of undeclared identifier 'allOnesIsValid'
        !allOnesIsValid) {
         ^
/Users/mfigurnov/Documents/matconvnet-github/matlab/src/vl_nnconv.cu:697:10: error: use of undeclared identifier 'tempIsValid'
        !tempIsValid) {
         ^
2 errors generated.
```

This commit fixes the issue.