### PR TITLE
Run all tests by default

### DIFF
--- a/matlab/xtest/vl_test_nnlayers.m
+++ b/matlab/xtest/vl_test_nnlayers.m
@@ -27,7 +27,7 @@ end
 rng(1) ;
 
 if nargin < 2
-  tests = 1:10 ;
+  tests = 1:13 ;
 end
 
 for l = tests


### PR DESCRIPTION
Seems like vl_test_nnlayers runs just a fraction of test by default.