### PR TITLE
Typo causes bug when using multiple loss functions

### DIFF
--- a/matlab/+dagnn/Layer.m
+++ b/matlab/+dagnn/Layer.m
@@ -116,7 +116,7 @@ classdef Layer < handle
         else
           net.vars(v).der = net.vars(v).der + derInputs{i} ;
         end
-        net.numPendingVarRefs(v) == net.numPendingVarRefs(v) + 1 ;
+        net.numPendingVarRefs(v) = net.numPendingVarRefs(v) + 1 ;
       end
 
       for i = 1:numel(par)


### PR DESCRIPTION
When there are multiple derivatives, they do not get accumulated.