### PR TITLE
Fixed bug with conv layer when number of channels < 1

### DIFF
--- a/matlab/+dagnn/Conv.m
+++ b/matlab/+dagnn/Conv.m
@@ -30,7 +30,11 @@ classdef Conv < dagnn.Filter
 
     function outputSizes = getOutputSizes(obj, inputSizes)
       outputSizes = getOutputSizes@dagnn.Filter(obj, inputSizes) ;
-      outputSizes{1}(3) = obj.size(4) ;
+      if length(obj.size) < 4
+          outputSizes{1}(3) = 1;
+      else
+        outputSizes{1}(3) = obj.size(4) ;
+      end
     end
 
     function params = initParams(obj)


### PR DESCRIPTION
This bug is caused by the fact that obj.size does not always return a 4x1 vector. It doesn't show the size of singleton dimensions. Same bug in Deconv layer.