### PR TITLE
Fix typo & bugs with ReLU in DagNN when conserving memory

### DIFF
--- a/matlab/+dagnn/ReLU.m
+++ b/matlab/+dagnn/ReLU.m
@@ -23,7 +23,8 @@ classdef ReLU < dagnn.ElementWise
       in = layer.inputIndexes ;
       out = layer.outputIndexes ;
       net.vars(out).value = vl_nnrelu(net.vars(in).value, [], obj.opts{:}) ;
-      if ~net.vars(in).precious
+      net.numPendingVarRefs(in) = net.numPendingVarRefs(in) - 1;
+      if ~net.vars(in).precious & net.numPendingVarRefs(in) == 0
         net.vars(in).value = [] ;
       end
     end
@@ -49,7 +50,7 @@ classdef ReLU < dagnn.ElementWise
       if net.numPendingVarRefs(in) == 0
           net.vars(in).der = derInput ;
       else
-          net.vars(in).der = net.vars(in).der + derInputs ;
+          net.vars(in).der = net.vars(in).der + derInput ;
       end
       net.numPendingVarRefs(in) = net.numPendingVarRefs(in) + 1 ;
     end


### PR DESCRIPTION
This bug happens when the input variable of ```ReLU``` has more than one output. 

To fix this, we need to update & consider ```numPendingVarRefs``` before releasing the memory of the input variable. 

Also fixed a typo from ```derInputs``` to ```derInput```. 