### PR TITLE
Add FixedDims flag to vl_imreadjpeg, added convert_matconvnet_caffe.m

### DIFF
--- a/matlab/vl_compilenn.m
+++ b/matlab/vl_compilenn.m
@@ -280,6 +280,7 @@ if opts.verbose > 1
 end
 if opts.debug
   flags.cc{end+1} = '-g' ;
+  flags.link{end+1} = '-g' ;
 else
   flags.cc{end+1} = '-DNDEBUG' ;
 end

--- a/utils/convert_matconvnet_caffe.m
+++ b/utils/convert_matconvnet_caffe.m
@@ -57,10 +57,16 @@ net.layers(dropout) = []; % Remove dropout layers
 
 if isfield(net, 'normalization') && isfield(net.normalization, 'imageSize')
     im_size = net.normalization.imageSize; 
-elseif isfield(net, 'normalization') && isfield(net.normalization, 'averageImage')
-    im_size = size(net.normalization.averageImage);
 else
     error('Missing image size. Please set net.normalization.imageSize');
+end
+
+if isfield(net, 'normalization') && isfield(net.normalization, 'averageImage')
+    averageImage_size = size(net.normalization.averageImage);
+    if averageImage_size(1) == 1 && averageImage_size(2) == 1
+        % constant value, we'll duplicate it to im_size
+        net.normalization.averageImage = repmat(net.normalization.averageImage, im_size(1), im_size(2));
+    end
 end
 
 % Write prototxt file
@@ -223,7 +229,7 @@ for idx = 1:length(net.layers)
                 weights = squeeze(weights);
             end
             caffe_net.layers(layer_name).params(1).set_data(weights); % set weights
-            caffe_net.layers(layer_name).params(2).set_data(net.layers{idx}.weights{2}'); % set bias        
+            caffe_net.layers(layer_name).params(2).set_data(net.layers{idx}.weights{2}(:)); % set bias        
         case {'relu', 'normalize', 'pool', 'softmax'}
                 % No weights - nothing to do                
         otherwise

--- a/utils/convert_matconvnet_caffe.m
+++ b/utils/convert_matconvnet_caffe.m
@@ -44,8 +44,14 @@ for idx = 1:length(net.layers)
     end
     
     % copy old filters,biases notation to weights
-    if isfield(net.layers{idx}, 'filters')        
+    if isfield(net.layers{idx}, 'filters')
         net.layers{idx}.weights = {net.layers{idx}.filters net.layers{idx}.biases};
+    end
+    
+    if isfield(net.layers{idx}, 'weights')
+        % Move GPU data back to CPU memory
+        net.layers{idx}.weights{1} = gather(net.layers{idx}.weights{1});
+        net.layers{idx}.weights{2} = gather(net.layers{idx}.weights{2});
     end
     
     % mark dropout layers for deletion (not needed at test time)

--- a/utils/convert_matconvnet_caffe.m
+++ b/utils/convert_matconvnet_caffe.m
@@ -1,0 +1,313 @@
+function convert_matconvnet_caffe(net, base_output_filename, test_img)
+% CONVERT_MATCONVNET_CAFFE export a MatConvNet network to Caffe format
+%   convert_matconvnet_caffe(net, base_output_filename, test_img)
+%   Export a MatConvNet network to Caffe format
+%
+%   Prerequisites:
+%     - MatConvNet
+%     - Caffe built with the new MatCaffe interface
+%
+%   Inputs:
+%     net:
+%       A MatConvNet network struct.
+%
+%     base_output_filename:
+%       Path to output file, without extension.
+%
+%     test_img:
+%       An image filename or array, on which the models will be tested to 
+%       compare their output.
+%
+%   Output:
+%     The following Caffe files will be created by the function:
+%       [base_output_filename '.prototxt'] - Network definition file
+%       [base_output_filename '.caffemodel'] - Binary Caffe model
+%       [base_output_filename '_mean_image.binaryproto'] (optional) -
+%         The average image that needs to be subtracted from the input
+%         (if set in net.normalization.averageImage).
+%
+%   Author: Zohar Bar-Yehuda
+
+
+[~, name] = fileparts(base_output_filename);
+
+if ismember(net.layers{end}.type, {'softmaxloss', 'weightedsoftmaxloss'})
+    net.layers{end}.type = 'softmax';
+end
+for idx = 1:length(net.layers)
+    if ~isfield(net.layers{idx}, 'name')
+        net.layers{idx}.name = sprintf('layer%d', idx);
+    end
+    if isfield(net.layers{idx}, 'filters')
+        % copy old filters,biases notation to weights
+        net.layers{idx}.weights = {net.layers{idx}.filters net.layers{idx}.biases};
+    end
+end
+
+if isfield(net, 'normalization') && isfield(net.normalization, 'imageSize')
+    im_size = net.normalization.imageSize; 
+elseif isfield(net, 'normalization') && isfield(net.normalization, 'averageImage')
+    im_size = size(net.normalization.averageImage);
+else
+    error('Missing image size. Please set net.normalization.imageSize');
+end
+
+% Write prototxt file
+prototxt_filename = [base_output_filename '.prototxt'];
+fid = fopen(prototxt_filename, 'w');
+
+fprintf(fid,'name: "%s"\n\n', name); % Network name
+
+% Input dimensions
+fprintf(fid, 'input: "data"\n');
+fprintf(fid, 'input_dim: 1\n');
+fprintf(fid, 'input_dim: %d\n', im_size(3));
+fprintf(fid, 'input_dim: %d\n', im_size(1));
+fprintf(fid, 'input_dim: %d\n\n', im_size(2));
+
+for idx = 1:length(net.layers)
+    % write layers
+    fprintf(fid,'layer {\n');
+    fprintf(fid,'  name: "%s"\n', net.layers{idx}.name); % Layer name
+    switch net.layers{idx}.type
+        case 'conv'
+            if size(net.layers{idx}.weights{1},1) > 1 || ...
+                    size(net.layers{idx}.weights{1},2) > 1
+                % Convolution layer                
+                fprintf(fid, '  type: "Convolution"\n');
+                write_order(fid, net.layers, idx);
+                fprintf(fid, '  convolution_param {\n');
+                write_kernel(fid, [size(net.layers{idx}.weights{1},1), size(net.layers{idx}.weights{1},2)]);
+                fprintf(fid, '    num_output: %d\n', size(net.layers{idx}.weights{1},4));
+                write_stride(fid, net.layers{idx});
+                if isfield(net.layers{idx}, 'pad') && length(net.layers{idx}.pad) == 4
+                    % Make sure pad is symmetrical
+                    if net.layers{idx}.pad(1) ~= net.layers{idx}.pad(2) || ...
+                            net.layers{idx}.pad(3) ~= net.layers{idx}.pad(4)
+                        error('Caffe only supports symmetrical padding');
+                    end
+                end
+                write_pad(fid, net.layers{idx});
+                fprintf(fid, '  }\n');
+            else
+                % Fully connected layer
+                fprintf(fid, '  type: "InnerProduct"\n');
+                write_order(fid, net.layers, idx);
+                fprintf(fid, '  inner_product_param {\n');                
+                fprintf(fid, '    num_output: %d\n', size(net.layers{idx}.weights{1},4));                
+                fprintf(fid, '  }\n');
+            end
+            
+        case 'relu'            
+            fprintf(fid, '  type: "ReLU"\n');
+            write_order(fid, net.layers, idx);
+            
+        case 'Sigmoid'
+            fprintf(fid, '  type: "ReLU"\n');
+            write_order(fid, net.layers, idx);     
+            
+        case 'pool'            
+            fprintf(fid, '  type: "Pooling"\n');
+            write_order(fid, net.layers, idx);
+            fprintf(fid, '  pooling_param {\n'); 
+            switch (net.layers{idx}.method)
+                case 'max'
+                    caffe_pool = 'MAX';
+                case 'avg'
+                    caffe_pool = 'AVE';
+                otherwise
+                    error('Unknown pooling type');
+            end
+            fprintf(fid, '    pool: %s\n', caffe_pool);
+            write_kernel(fid, net.layers{idx}.pool);
+            write_stride(fid, net.layers{idx});
+            write_pad(fid, net.layers{idx});
+            fprintf(fid, '  }\n');                                    
+            
+        case 'normalize' 
+            % MATLAB param = [local_size, kappa, alpha/local_size, beta]
+            fprintf(fid, '  type: "LRN"\n');
+            write_order(fid, net.layers, idx);
+            fprintf(fid, '  lrn_param {\n'); 
+            fprintf(fid, '    local_size: %d\n', net.layers{idx}.param(1));
+            fprintf(fid, '    k: %f\n', net.layers{idx}.param(2));
+            fprintf(fid, '    alpha: %f\n', net.layers{idx}.param(3)*net.layers{idx}.param(1));
+            fprintf(fid, '    beta: %f\n', net.layers{idx}.param(4));
+            fprintf(fid, '  }\n');
+            
+        case 'softmax'            
+            fprintf(fid, '  type: "Softmax"\n');
+            write_order(fid, net.layers, idx);                
+    end    
+    fprintf(fid,'}\n\n');
+end
+fclose(fid);
+
+
+% Write binary model file
+caffe.set_mode_cpu();
+caffe_net = caffe.Net(prototxt_filename,'test');
+first_conv = true;
+for idx = 1:length(net.layers)    
+    layer_type = net.layers{idx}.type;
+    layer_name = net.layers{idx}.name;
+    switch layer_type
+        case 'conv'  
+            weights = net.layers{idx}.weights{1};
+            weights = permute(weights, [2 1 3 4]); % Convert from HxWxCxN to WxHxCxN per Caffe's convention
+            if first_conv
+                if size(weights,3) == 3
+                    % We assume this is an image convolution, need to convert RGB to BGR
+                    weights = weights(:,:, [3 2 1], :); % Convert from RGB to BGR channel order per Caffe's convention
+                end
+                first_conv = false; % Do this only for first convolution;
+            end
+            if size(weights,1) == 1 && size(weights,2) == 1
+                % Fully connected layer, squeeze to 2 dims
+                weights = squeeze(weights);
+            end
+            caffe_net.layers(layer_name).params(1).set_data(weights); % set weights
+            caffe_net.layers(layer_name).params(2).set_data(net.layers{idx}.weights{2}'); % set bias        
+        case {'relu', 'normalize', 'pool', 'softmax'}
+                % No weights - nothing to do                
+        otherwise
+            error('Unknown layer type %s', layer_type)
+    end            
+            
+end
+model_filename = [base_output_filename '.caffemodel'];
+caffe_net.save(model_filename);
+
+% Save average image
+if isfield(net, 'normalization') && isfield(net.normalization, 'averageImage')    
+    mean_bgr = matlab_img_to_caffe(net.normalization.averageImage); 
+    meanfile = [base_output_filename '_mean_image.binaryproto'];
+    caffe.io.write_mean(mean_bgr, meanfile)
+else
+    meanfile = [];
+end
+
+% Test
+cpu_iters = 10;
+gpu_iters  = 200;
+fprintf('Testing:\n');
+caffe_net2 = caffe.Net(prototxt_filename,model_filename, 'test');
+if ischar(test_img)
+    test_img = imread(test_img);
+end
+if size(test_img,1) ~= im_size(1) || ...
+   size(test_img,2) ~= im_size(2)
+   test_img = imresize(test_img, im_size(1:2));
+end
+
+test_img = single(test_img);
+img_caffe = matlab_img_to_caffe(test_img);
+if isfield(net.normalization, 'averageImage');
+    test_img = test_img - net.normalization.averageImage;
+end
+tic
+for i=1:cpu_iters
+    resmat = vl_simplenn(net, test_img);
+end
+fprintf('MatConvNet CPU time: %.1f msec\n', toc/cpu_iters*1000);
+prob_mat = resmat(end).x;
+
+if ~isempty(meanfile)
+    mean_img_caffe = caffe.io.read_mean(meanfile);
+    img_caffe = img_caffe - mean_img_caffe;
+end
+tic
+for i=1:cpu_iters
+    res = caffe_net2.forward({img_caffe});
+end
+prob_caffe = res{1};
+fprintf('Caffe CPU time: %.1f msec\n', toc/cpu_iters*1000);
+
+gpu_mode = gpuDeviceCount > 0;
+if gpu_mode
+    for idx = 1:length(net.layers)
+        if isfield(net.layers{idx}, 'weights')
+            net.layers{idx}.weights{1} = gpuArray(net.layers{idx}.weights{1});
+            net.layers{idx}.weights{2} = gpuArray(net.layers{idx}.weights{2});
+        end
+    end
+    test_img = gpuArray(test_img);
+    tic
+    for i=1:gpu_iters
+        resmat = vl_simplenn(net, test_img);        
+    end    
+    fprintf('MatConvNet GPU time: %.2f msec\n', toc/gpu_iters*1000);
+    prob_mat = resmat(end).x;
+    
+    caffe.set_mode_gpu();
+    tic
+    for i=1:gpu_iters
+        res = caffe_net2.forward({img_caffe});
+    end
+    fprintf('Caffe GPU time: %.2f msec\n', toc/gpu_iters*1000);
+    prob_caffe = res{1};
+end
+
+
+if isa(prob_mat, 'gpuArray')
+    prob_mat = gather(prob_mat);
+end
+fprintf('MatConvNet result: %s\n', sprintf('%f ', prob_mat));
+fprintf('Caffe result: %s\n', sprintf('%f ', prob_caffe));
+max_diff = max(abs(prob_mat(:) - prob_caffe(:)));
+fprintf('Max MatConNet/Caffe diff: %f\n', max_diff);
+assert(max_diff <= 1e-5);
+
+
+function write_stride(fid, layer)
+if isfield(layer, 'stride')
+    if length(layer.stride) == 1
+        fprintf(fid, '    stride: %d\n', layer.stride);
+    elseif length(layer.stride) == 2
+        fprintf(fid, '    stride_h: %d\n', layer.stride(1));
+        fprintf(fid, '    stride_w: %d\n', layer.stride(2));
+    end
+end
+
+function write_kernel(fid, kernel_size)
+if length(kernel_size) == 1
+    fprintf(fid, '    kernel_size: %d\n', kernel_size);
+elseif length(kernel_size) == 2
+    fprintf(fid, '    kernel_h: %d\n', kernel_size(1));
+    fprintf(fid, '    kernel_w: %d\n', kernel_size(2));
+end
+
+
+function write_pad(fid, layer)
+if isfield(layer, 'pad')
+    if length(layer.pad) == 1
+        fprintf(fid, '    pad: %d\n', layer.pad);
+    elseif length(layer.pad) == 4
+        fprintf(fid, '    pad_h: %d\n', layer.pad(1));
+        fprintf(fid, '    pad_w: %d\n', layer.pad(3));
+    else
+        error('pad vector size must be 1 or 4')
+    end
+end
+
+function write_order(fid, layers, idx)
+if idx > 1
+    bottom_name = layers{idx-1}.name;
+else
+    bottom_name = 'data';
+end
+if idx < length(layers)
+    top_name = layers{idx}.name;
+else
+    top_name = 'prob';
+end
+fprintf(fid, '  bottom: "%s"\n', bottom_name);
+fprintf(fid, '  top: "%s"\n', top_name);
+
+
+function img = matlab_img_to_caffe(img)
+img = single(img);
+img = permute(img, [2 1 3 4]); % Convert from HxWxCxN to WxHxCxN per Caffe's convention
+if size(img,3) == 3
+    img = img(:,:, [3 2 1], :); % Convert from RGB to BGR channel order per Caffe's convention
+end

--- a/utils/convert_matconvnet_caffe.m
+++ b/utils/convert_matconvnet_caffe.m
@@ -68,12 +68,6 @@ for idx = 1:length(net.layers)
         net.layers{idx}.weights = {net.layers{idx}.filters net.layers{idx}.biases};
     end
     
-    if isfield(net.layers{idx}, 'weights')
-        % Move GPU data back to CPU memory
-        net.layers{idx}.weights{1} = gather(net.layers{idx}.weights{1});
-        net.layers{idx}.weights{2} = gather(net.layers{idx}.weights{2});
-    end
-    
     % mark dropout layers for deletion (not needed at test time)
     if isequal(net.layers{idx}.type, 'dropout')
         dropout(idx) = true;

--- a/utils/convert_matconvnet_caffe.m
+++ b/utils/convert_matconvnet_caffe.m
@@ -92,7 +92,7 @@ for idx = 1:length(net.layers)
         case 'conv'
             if size(net.layers{idx}.weights{1},1) > 1 || ...
                     size(net.layers{idx}.weights{1},2) > 1
-                % Convolution layer                
+                % Convolution layer
                 fprintf(fid, '  type: "Convolution"\n');
                 write_order(fid, net.layers, idx);
                 fprintf(fid, '  convolution_param {\n');
@@ -107,6 +107,13 @@ for idx = 1:length(net.layers)
                     end
                 end
                 write_pad(fid, net.layers{idx});
+                layer_input_size = size(dummy_data);
+                num_groups = layer_input_size(3) / size(net.layers{idx}.weights{1},3);
+                assert(mod(num_groups,1) == 0);
+                if num_groups > 1
+                    fprintf(fid, '    group: %d\n', num_groups);
+                end
+                
                 fprintf(fid, '  }\n');
             else
                 % Fully connected layer


### PR DESCRIPTION
This PR solves issue #254. Did some testing and it seems to be working well. I hope the reuse of the error field as an indication for the need for dimensions validation is acceptable.

* When using Prefetch, this can greatly improve speed in cases where all
the input images have the same size. This is achieved by peeking only at
the 1st file to check its dimensions, and assuming all other files have
the same dimensions. In case a file has different dimensions, it is
skipped and a warning is displayed.
* Fixed Debug flag in compilation (needed in link as well in Windows)
* Added a function to export MatConvNet models to Caffe, based on the MatCaffe interface. I tested it on a few networks (VGG + a few simple ones) and it seems to work properly. Would appreciate if you can test on a few more networks, as I might have missed some cases. 