### PR TITLE
Change function name to match errorFunction handle @ line 104

### DIFF
--- a/examples/cnn_train.m
+++ b/examples/cnn_train.m
@@ -206,7 +206,7 @@ err(1,1) = sum(sum(sum(mass .* error(:,:,1,:)))) ;
 err(2,1) = sum(sum(sum(mass .* min(error(:,:,1:5,:),[],3)))) ;
 
 % -------------------------------------------------------------------------
-function err = error_binaryclass(opts, labels, res)
+function err = error_binary(opts, labels, res)
 % -------------------------------------------------------------------------
 predictions = gather(res(end-1).x) ;
 error = bsxfun(@times, predictions, labels) < 0 ;


### PR DESCRIPTION
Hi,

line 104 gets a handle to error_binary() but the function below was wrongly named error_binaryclass()
The function name was changed to correct this.
