### PR TITLE
Remove MEX unsupported -cxx compile flag

### DIFF
--- a/matlab/vl_compilenn.m
+++ b/matlab/vl_compilenn.m
@@ -338,7 +338,6 @@ end
 flags.link{end+1} = '-largeArrayDims' ;
 flags.mexcc = flags.cc ;
 flags.mexcc{end+1} = '-largeArrayDims' ;
-flags.mexcc{end+1} = '-cxx' ;
 if strcmp(arch, 'maci64') && opts.enableGpu && cuver < 70000
   % CUDA prior to 7.0 on Mac require GCC libstdc++ instead of the native
   % Clang libc++. This should go away in the future.
@@ -363,7 +362,6 @@ end
 if opts.enableGpu
   flags.mexcu = flags.cc ;
   flags.mexcu{end+1} = '-largeArrayDims' ;
-  flags.mexcu{end+1} = '-cxx' ;
   flags.mexcu(end+1:end+2) = {'-f' mex_cuda_config(root)} ;
   flags.mexcu{end+1} = ['NVCCFLAGS=' opts.cudaArch '$NVCC_FLAGS'] ;
 end

--- a/matlab/vl_compilenn.m
+++ b/matlab/vl_compilenn.m
@@ -338,6 +338,10 @@ end
 flags.link{end+1} = '-largeArrayDims' ;
 flags.mexcc = flags.cc ;
 flags.mexcc{end+1} = '-largeArrayDims' ;
+if ~ispc
+	flags.mexcc{end+1} = '-cxx' ; % unix required compile flag, windows not required
+end
+
 if strcmp(arch, 'maci64') && opts.enableGpu && cuver < 70000
   % CUDA prior to 7.0 on Mac require GCC libstdc++ instead of the native
   % Clang libc++. This should go away in the future.
@@ -362,6 +366,9 @@ end
 if opts.enableGpu
   flags.mexcu = flags.cc ;
   flags.mexcu{end+1} = '-largeArrayDims' ;
+  if ~ispc
+	flags.mexcu{end+1} = '-cxx' ;  % unix required compile flag, windows not required
+  end
   flags.mexcu(end+1:end+2) = {'-f' mex_cuda_config(root)} ;
   flags.mexcu{end+1} = ['NVCCFLAGS=' opts.cudaArch '$NVCC_FLAGS'] ;
 end


### PR DESCRIPTION
MATLAB 2013a mex does not support the "cxx" flag and I have doubts that it is even required in matlab/vl_compilenn.m. Providing patch to remove it.

Example of compile failure:
http://www.mathworks.com/matlabcentral/answers/201708-mex-compile-error-unrecognized-switch-cxx