### PR TITLE
Fixed the import caffe and import-fcn scripts

### DIFF
--- a/utils/import-caffe.py
+++ b/utils/import-caffe.py
@@ -17,7 +17,7 @@ from numpy import array
 import scipy
 import scipy.io
 import scipy.misc
-import google.protobuf
+import google.protobuf.text_format
 from ast import literal_eval as make_tuple
 from layers import *
 

--- a/utils/import-fcn.sh
+++ b/utils/import-fcn.sh
@@ -28,10 +28,17 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
 
+# Use the python implementation of protocol buffers to load gigantic caffe models.
+# The CPP implementation may not load these files on all systems out-of-the-box.
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 converter="python $SCRIPTPATH/import-caffe.py"
 data="$SCRIPTPATH/../data"
 
 mkdir -p "$data/tmp/fcn"
+
+if [ ! -d "$data/models/" ]; then
+    mkdir "$data/models"
+fi
 
 function get()
 {


### PR DESCRIPTION
Minor code modifications to ensure smooth user experience.

- in `import-caffe.py` it should say `import google.protobuf.text_format`
- in `import-fcn.sh` it should make the `models` directory if it doesn't exist (which is not there by default and can lead to ambiguous error messages).
- It's safer to switch to python protocol buffers to load the gigantic caffe models. Protobuf doesn't load messages heavier than 64 MB by default.