### PR TITLE
fix isotropic resizing in vl_imreadjpeg.cu

### DIFF
--- a/matlab/src/vl_imreadjpeg.cu
+++ b/matlab/src/vl_imreadjpeg.cu
@@ -397,7 +397,10 @@ void mexFunction(int nout, mxArray *out[],
             break ;
           case kResizeIsotropic:
           {
-            float scale = (std::max)((float)resizeWidth / shape.width,
+	    // NOTE this will always resizes height to resizeHeight
+	    //      because resizeWidth has the dummy value of 1
+            //float scale = (std::max)((float)resizeWidth / shape.width,
+            float scale = (std::max)((float)resizeHeight / shape.width,
                                      (float)resizeHeight / shape.height);
             resizedShape.height = roundf(resizedShape.height * scale) ;
             resizedShape.width = roundf(resizedShape.width * scale) ;


### PR DESCRIPTION
Bug description: 

Given a scalar resize argument `size`, vl_imreadjpeg resizes the height to `size` isotropically, instead of resizing the shorter length to match `size`. 