### PR TITLE
vl_compilenn compatiblility, fix #460

### DIFF
--- a/matlab/vl_compilenn.m
+++ b/matlab/vl_compilenn.m
@@ -325,7 +325,7 @@ if opts.enableGpu
 end
 if opts.enableCudnn
   flags.cc{end+1} = '-DENABLE_CUDNN' ;
-  flags.cc{end+1} = ['-I' opts.cudnnIncludeDir] ;
+  flags.cc{end+1} = ['-I"' opts.cudnnIncludeDir '"'] ;
 end
 if opts.enableDouble
   flags.cc{end+1} = '-DENABLE_DOUBLE' ;
@@ -344,7 +344,7 @@ if opts.enableImreadJpeg
 end
 
 if opts.enableGpu
-  flags.link = horzcat(flags.link, {['-L' opts.cudaLibDir], '-lcudart', '-lcublas'}) ;
+  flags.link = horzcat(flags.link, {['-L"' opts.cudaLibDir '"'], '-lcudart', '-lcublas'}) ;
   switch arch
     case {'maci64', 'glnxa64'}
       flags.link{end+1} = '-lmwgpu' ;
@@ -352,7 +352,7 @@ if opts.enableGpu
       flags.link{end+1} = '-lgpu' ;
   end
   if opts.enableCudnn
-    flags.link{end+1} = ['-L' opts.cudnnLibDir] ;
+    flags.link{end+1} = ['-L"' opts.cudnnLibDir '"'] ;
     flags.link{end+1} = '-lcudnn' ;
   end
 end


### PR DESCRIPTION
#460 :

> I recommend this change [vl_compilenn:315]:
> 
> flags.cc{end+1} = ['-I' opts.cudnnIncludeDir] ;
> => 
> flags.cc{end+1} = ['-I"' opts.cudnnIncludeDir '"'] ;
> 
> Otherwise if the include directory looks like this "C:\Program Files..." i.e., there are spaces, it won't compile. This should work in linux, too.

tested on Win 7 amd64