### PR TITLE
Update build.m

### DIFF
--- a/matlab/autonn/@Net/build.m
+++ b/matlab/autonn/@Net/build.m
@@ -186,7 +186,7 @@ function build(net, varargin)
         % its var index: it's the output derivative for the current layer
         layer.inputVars(end+1) = obj.outputVar + 1 ;
       end
-
+      layer = orderfields(layer);
       net.backward(numel(idx) - k + 1) = layer ;
     end
 


### PR DESCRIPTION
At present the layer struct fields are not ordered in the ASCII order which leads to a dimension mismatch error when assigning to net.backward.