### PR TITLE
[Small bug fix] Debug mode compile failure

### DIFF
--- a/matlab/src/bits/impl/bilinearsampler_gpu.cu
+++ b/matlab/src/bits/impl/bilinearsampler_gpu.cu
@@ -250,11 +250,11 @@ forward_backward
   assert(divides(inCardinality, outCardinality)) ;
 
   // forward conditions
-  assert(backward || data) ;
-  assert(backward || output) ;
+  //assert(backward || data) ;
+  //assert(backward || output) ;
 
   // backward conditions
-  assert(!backward || derOutput) ;
+  //assert(!backward || derOutput) ;
   assert(!backwardData || derData) ;
   assert(!backwardGrid || derGrid) ;
   assert(!backwardGrid || data) ;


### PR DESCRIPTION
While compiling gpu + debug mode matconvnet, bilinearsampler_gpu.cu occurred the following error message.

`matlab/src/bits/impl/bilinearsampler_gpu.cu(252):` error: identifier "backward" is undefined

It is occurred due to leftovers, macro calls of assert() with non-existing "backward" keyword.
I commented out the assert() calls related with "backward", so that compiling with GPU+debug mode can be smoothly done.