### PR TITLE
Dot visualization of dagNN object

### DIFF
--- a/matlab/+dagnn/@DagNN/print.m
+++ b/matlab/+dagnn/@DagNN/print.m
@@ -427,6 +427,8 @@ fprintf('Dot output:\n%s\n', result) ;
 
 %f = fopen(out,'r') ; file=fread(f, 'char=>char')' ; fclose(f) ;
 switch computer
+  case {'PCWIN64', 'PCWIN'}
+    system(sprintf('start "" "%s"', out)) ;
   case 'MACI64'
     system(sprintf('open "%s"', out)) ;
   case 'GLNXA64'

--- a/matlab/+dagnn/@DagNN/print.m
+++ b/matlab/+dagnn/@DagNN/print.m
@@ -33,7 +33,7 @@ function str = print(obj, inputSizes, varargin)
 %      for a `digraph` (supported in MATLAB>=R2015b) and the last one
 %      prints a graph  in `dot` format. In case of zero outputs, it
 %      attmepts to compile and visualise the dot graph using `dot` command
-%      and `display` (Linux) or `open` (Mac OSX) on your system.
+%      and `start` (Windows), `display` (Linux) or `open` (Mac OSX) on your system.
 %      In the latter case, all variables and layers are included in the
 %      graph, regardless of the other parameters.
 %


### PR DESCRIPTION
This request is about the dot visualization of dagNN object.

1. Add command to open the dot visualization for Windows. Previously, such commands are only provided for Linux & Mac.

2. Automatically detect output format for generated dot figures. For examples, now users can provide a path string 'a/b/c.svg' to generate SVG figures instead of PDF figures. If associated with a particular application, e.g. Chrome, the SVG file is opened automatically.