### PR TITLE
Include a round() function for C++99 and C++03 support

### DIFF
--- a/matlab/src/bits/impl/roipooling_cpu.cpp
+++ b/matlab/src/bits/impl/roipooling_cpu.cpp
@@ -23,6 +23,13 @@ the terms of the BSD license (see the COPYING file).
 using std::max ;
 using std::min ;
 
+/* For C++ 99 and 03 round() support, compilation with Visual Studio 2010 */
+template <typename NumberType>
+NumberType round(NumberType number){
+	return (NumberType) floor( (double) (number + 0.5));
+}
+
+
 /* ---------------------------------------------------------------- */
 /*                                            max roipooling helper */
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
Created a generic function to round off values of any type.

This fixed compilation errors when using Matlab 2013a with Visual Studio C++ 2010