### PR TITLE
Fix activation of compatibility functions.

### DIFF
--- a/matlab/vl_setupnn.m
+++ b/matlab/vl_setupnn.m
@@ -15,7 +15,7 @@ addpath(fullfile(root, 'matlab', 'simplenn')) ;
 addpath(fullfile(root, 'matlab', 'xtest')) ;
 addpath(fullfile(root, 'examples')) ;
 
-if ~exist('gather')
+if ~exist('gather') || ~exist('labindex') || ~exist('numlabs')
   warning('The MATLAB Parallel Toolbox does not seem to be installed. Activating compatibility functions.') ;
   addpath(fullfile(root, 'matlab', 'compatibility', 'parallel')) ;
 end


### PR DESCRIPTION
In Matlab2016b is function gather that is not part of the Parallel Toolbox so the condition doesn't include compatibility functions even if Parallel Toolbox is not installed (see https://www.mathworks.com/help/matlab/ref/gather.html). 
Fixed by checking all three functions that will be patched using parallel compatibility.