### PR TITLE
fix build break due to incorrect memset call

### DIFF
--- a/matlab/src/vl_imreadjpeg.cu
+++ b/matlab/src/vl_imreadjpeg.cu
@@ -264,7 +264,7 @@ Batch::Item::Item(Batch const & batch)
   state(ready),
   flip(false)
 {
-  memset(errorMessage,sizeof(errorMessage),0) ;
+  memset(errorMessage,0,sizeof(errorMessage)) ;
 }
 
 mxArray * Batch::Item::relinquishArray()


### PR DESCRIPTION
The second parameter and the third parameter of the memset function are incorrectly swapped. The second parameter should mean the intended value and the third is the size. This error caused compiling failure.

fix #779 