### PR TITLE
resolve build failure due to -O

### DIFF
--- a/matlab/vl_compilenn.m
+++ b/matlab/vl_compilenn.m
@@ -337,7 +337,7 @@ if opts.debug
   flags.base{end+1} = '-g' ;
   flags.base{end+1} = '-DDEBUG' ;
 else
-  flags.base{end+1} = '-O' ;
+  flags.base{end+1} = '-O0' ;
   flags.base{end+1} = '-DNDEBUG' ;
 end
 


### PR DESCRIPTION
cuda 10.1 on ubuntu 18 with gcc 4.9 will fail to build with the following:

nvcc fatal   : '-D_FORCE_INLINES': expected a number

this is caused by the use of -O, adding a number -O0 solves it.

fix #1212 