### PR TITLE
Make vl_setupnn more transparent to mcc

### DIFF
--- a/matlab/vl_setupnn.m
+++ b/matlab/vl_setupnn.m
@@ -8,18 +8,18 @@ function vl_setupnn()
 % This file is part of the VLFeat library and is made available under
 % the terms of the BSD license (see the COPYING file).
 
-root = vl_rootnn() ;
-addpath(fullfile(root, 'matlab')) ;
-addpath(fullfile(root, 'matlab', 'mex')) ;
-addpath(fullfile(root, 'matlab', 'simplenn')) ;
-addpath(fullfile(root, 'matlab', 'xtest')) ;
-addpath(fullfile(root, 'examples')) ;
+root = fileparts(which('vl_setupnn'));
+addpath(fullfile(root)) ;
+addpath(fullfile(root, 'mex')) ;
+addpath(fullfile(root, 'simplenn')) ;
+addpath(fullfile(root, 'xtest')) ;
+addpath(fullfile(root, '..', 'examples')) ;
 
-if ~exist('gather')
+if ~exist('gather.m', 'file')
   warning('The MATLAB Parallel Toolbox does not seem to be installed. Activating compatibility functions.') ;
   addpath(fullfile(root, 'matlab', 'compatibility', 'parallel')) ;
 end
 
-if numel(dir(fullfile(root, 'matlab', 'mex', 'vl_nnconv.mex*'))) == 0
+if ~exist(['vl_nnconv.', mexext()], 'file')
   warning('MatConvNet is not compiled. Consider running `vl_compilenn`.');
 end


### PR DESCRIPTION
The Matlab compiler (mcc) can be used to bundle matlab applications and all found dependencies. I tried to compile eeglab and had some problems bundling matconvnet without just including the entire folder.

With the proposed changes, the mcc can `vl_setupnn` discover more of matconvnet, especially the mex-files for the target platform.